### PR TITLE
Set ZIM_HOME before zimfw install to avoid undefined variable error

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -68,6 +68,7 @@ success "Tools installed"
 
 # ── 6. Zim modules ────────────────────────────────────────────────────────────
 info "Installing Zim modules..."
+export ZIM_HOME="${ZIM_HOME:-$HOME/.zim}"
 source ~/.zshrc 2>/dev/null || true
 zimfw install
 success "Zim modules installed"


### PR DESCRIPTION
.zshrc references ZIM_HOME inline with a default but never exports it, leaving zimfw without the variable it needs.
