### PR TITLE
Store git identity in ~/.gitconfig.local to avoid leaking it into dot…

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -22,6 +22,9 @@
 [init]
 	defaultBranch = main
 
+[include]
+	path = ~/.gitconfig.local
+
 [alias]
 	st   = status
 	co   = checkout

--- a/install.sh
+++ b/install.sh
@@ -86,12 +86,11 @@ if [[ ! -d ~/.tmux/plugins/tpm ]]; then
   git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm
 fi
 
-# Git identity
+# Git identity (stored in ~/.gitconfig.local, not tracked by dotfiles)
 if [[ -z $(git config --global user.name) ]]; then
-  print -n "Git name:  "; read git_name
-  print -n "Git email: "; read git_email
-  git config --global user.name  "$git_name"
-  git config --global user.email "$git_email"
+  print -n "Git name:  "; read git_name < /dev/tty
+  print -n "Git email: "; read git_email < /dev/tty
+  print "[user]\n\tname  = $git_name\n\temail = $git_email" >> ~/.gitconfig.local
 fi
 
 # Set zsh as default shell


### PR DESCRIPTION
…files

- Add [include] path = ~/.gitconfig.local to .gitconfig
- Read git name/email from /dev/tty so prompts wait for input
- Write identity to ~/.gitconfig.local instead of --global (which would write into the symlinked dotfiles .gitconfig)

https://claude.ai/code/session_01SgvazZnaPEhRRHSQ14YvPB