### PR TITLE
Add missing prompt-pwd dependency for eriner theme

### DIFF
--- a/.zimrc
+++ b/.zimrc
@@ -20,6 +20,7 @@ zmodule zsh-users/zsh-completions --fpath src
 zmodule completion
 
 # Prompt
+zmodule prompt-pwd
 zmodule eriner
 
 # Plugins (must come after completion)


### PR DESCRIPTION
The eriner prompt module calls prompt-pwd but the module wasn't listed in .zimrc, causing 'command not found: prompt-pwd' on shell startup.

https://claude.ai/code/session_01SgvazZnaPEhRRHSQ14YvPB