### PR TITLE
Fix terraform completion modifying tracked .zshrc via symlink

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -16,8 +16,9 @@ export HOMEBREW_NO_AUTO_UPDATE=1
 # start Zim
 source ${ZIM_HOME:-~/.zim}/init.zsh
 
-# enable azure-cli completion (cached, refreshed weekly)
+# enable bash-style completions (terraform, azure-cli)
 autoload -U +X bashcompinit && bashcompinit
+complete -o nospace -C "$(brew --prefix)/bin/terraform" terraform
 _az_cache=~/.cache/zsh/az_completion.zsh
 if [[ ! -f $_az_cache ]] || [[ -n $(find $_az_cache -mtime +7 2>/dev/null) ]]; then
   mkdir -p ~/.cache/zsh && cat $(brew --prefix)/etc/bash_completion.d/az > $_az_cache

--- a/install.sh
+++ b/install.sh
@@ -77,11 +77,6 @@ success "Zim modules installed"
 # ── 7. Post-install ───────────────────────────────────────────────────────────
 info "Running post-install steps..."
 
-# Terraform shell completion (idempotent)
-if command -v terraform &>/dev/null; then
-  terraform -install-autocomplete 2>/dev/null || true
-fi
-
 # TPM (tmux plugin manager)
 if [[ ! -d ~/.tmux/plugins/tpm ]]; then
   git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm


### PR DESCRIPTION
terraform -install-autocomplete appended directly to ~/.zshrc, which is a symlink into the dotfiles repo. This dirtied the tracked file on every fresh install. Moved the completion line into .zshrc alongside the other bashcompinit-based completions and removed the install.sh call entirely.

https://claude.ai/code/session_01SgvazZnaPEhRRHSQ14YvPB