### PR TITLE
Improve VS Code settings and extensions

### DIFF
--- a/vscode/extensions.txt
+++ b/vscode/extensions.txt
@@ -11,7 +11,8 @@ cweijan.vscode-database-client2
 # Languages & Formatting
 redhat.vscode-yaml
 ms-python.python
-ms-python.black-formatter
+ms-python.vscode-pylance
+charliermarsh.ruff
 tamasfe.even-better-toml
 golang.go
 
@@ -29,11 +30,13 @@ pkief.material-icon-theme
 
 # Remote
 ms-vscode-remote.remote-ssh
+ms-vscode-remote.remote-ssh-edit
+ms-vscode-remote.remote-containers
 
 # Utilities
 esbenp.prettier-vscode
 streetsidesoftware.code-spell-checker
 usernamehw.errorlens
 editorconfig.editorconfig
-christian-kohler.path-intellisense
-yzhang.markdown-all-in-one
+ms-vscode.makefile-tools
+github.remotehub

--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -6,17 +6,19 @@
   "editor.tabSize": 4,
   "editor.wordWrap": "off",
   "editor.formatOnSave": true,
+  "editor.formatOnPaste": true,
   "editor.rulers": [100],
   "editor.minimap.enabled": false,
   "editor.renderWhitespace": "boundary",
   "editor.bracketPairColorization.enabled": true,
+  "editor.guides.bracketPairs": "active",
+  "editor.inlayHints.enabled": "on",
+  "editor.smoothScrolling": true,
+  "editor.cursorBlinking": "smooth",
+  "editor.cursorSmoothCaretAnimation": "on",
   "editor.suggestSelection": "first",
   "editor.stickyScroll.enabled": true,
   "editor.linkedEditing": true,
-  "editor.codeActionsOnSave": {
-    "source.organizeImports": "explicit"
-  },
-
   // Files
   "files.autoSave": "onWindowChange",
   "files.trimTrailingWhitespace": true,
@@ -33,6 +35,7 @@
   },
 
   // Search
+  "search.smartCase": true,
   "search.exclude": {
     "**/node_modules": true,
     "**/.terraform": true,
@@ -44,11 +47,13 @@
   // Terminal
   "terminal.integrated.fontFamily": "'JetBrains Mono', 'Menlo', monospace",
   "terminal.integrated.fontSize": 13,
+  "terminal.integrated.persistentSessionReviveProcess": "never",
 
   // Git
   "git.autofetch": true,
   "git.confirmSync": false,
   "git.enableSmartCommit": true,
+  "git.openRepositoryInParentFolders": "never",
   "diffEditor.ignoreTrimWhitespace": false,
 
   // Workbench
@@ -56,18 +61,21 @@
   "workbench.iconTheme": "material-icon-theme",
   "workbench.startupEditor": "none",
   "workbench.editor.enablePreview": false,
+  "workbench.editor.wrapTabs": true,
+  "workbench.list.smoothScrolling": true,
   "explorer.confirmDelete": false,
   "explorer.confirmDragAndDrop": false,
+  "security.workspace.trust.enabled": false,
+  "telemetry.telemetryLevel": "off",
+  "extensions.autoUpdate": false,
 
   // Extensions: Terraform
   "terraform.experimentalFeatures.validateOnSave": true,
   "[terraform]": {
-    "editor.defaultFormatter": "hashicorp.terraform",
-    "editor.formatOnSave": true
+    "editor.defaultFormatter": "hashicorp.terraform"
   },
   "[terraform-vars]": {
-    "editor.defaultFormatter": "hashicorp.terraform",
-    "editor.formatOnSave": true
+    "editor.defaultFormatter": "hashicorp.terraform"
   },
 
   // Extensions: YAML
@@ -77,11 +85,34 @@
     "https://raw.githubusercontent.com/compose-spec/compose-spec/master/schema/compose-spec.json": "docker-compose*.yml"
   },
 
+  // Extensions: JSON
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+
+  // Extensions: YAML (formatter override)
+  "[yaml]": {
+    "editor.defaultFormatter": "redhat.vscode-yaml"
+  },
+
   // Extensions: Python (via mise)
   "python.defaultInterpreterPath": "${env:HOME}/.local/share/mise/shims/python",
   "[python]": {
-    "editor.defaultFormatter": "ms-python.black-formatter",
-    "editor.formatOnSave": true
+    "editor.defaultFormatter": "charliermarsh.ruff",
+    "editor.codeActionsOnSave": {
+      "source.fixAll.ruff": "explicit",
+      "source.organizeImports.ruff": "explicit"
+    }
+  },
+
+  // Extensions: Go
+  "go.toolsManagement.autoUpdate": false,
+  "[go]": {
+    "editor.defaultFormatter": "golang.go",
+    "editor.insertSpaces": false
   },
 
   // Extensions: GitLens


### PR DESCRIPTION
Settings:
- editor.guides.bracketPairs: active, inlayHints.enabled: on
- editor.smoothScrolling, cursorBlinking: smooth, cursorSmoothCaretAnimation: on
- editor.formatOnPaste: true
- search.smartCase: true
- terminal.integrated.persistentSessionReviveProcess: never
- workbench.editor.wrapTabs: true
- workbench.list.smoothScrolling: true
- security.workspace.trust.enabled: false, telemetry.telemetryLevel: off
- extensions.autoUpdate: false
- git.openRepositoryInParentFolders: never
- Explicit formatter overrides: JSON/JSONC (prettier), YAML (redhat), Python (ruff), Go (golang.go)
- [go]: insertSpaces: false (Go uses real tabs)
- [python]: ruff code actions replacing global source.organizeImports
- [terraform/terraform-vars]: removed redundant formatOnSave

Extensions added:
- ms-python.vscode-pylance, charliermarsh.ruff, ms-vscode-remote.remote-containers
- ms-vscode-remote.remote-ssh-edit, ms-vscode.makefile-tools, github.remotehub

Extensions removed:
- ms-python.black-formatter (replaced by ruff)
- christian-kohler.path-intellisense, yzhang.markdown-all-in-one (redundant)

https://claude.ai/code/session_01SgvazZnaPEhRRHSQ14YvPB