### PR TITLE
fix: add JetBrains Mono font and github.copilot extension

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,4 +1,5 @@
 tap "hashicorp/tap"
+tap "homebrew/cask-fonts"
 tap "microsoft/mssql-release", "https://github.com/Microsoft/homebrew-mssql-release"
 
 # Terminal
@@ -37,6 +38,9 @@ brew "pre-commit"
 brew "git-delta"
 brew "mise"
 brew "typst"
+
+# Fonts
+cask "font-jetbrains-mono"
 
 # Apps
 cask "claude-code"

--- a/vscode/extensions.txt
+++ b/vscode/extensions.txt
@@ -18,6 +18,7 @@ golang.go
 
 # AI
 anthropic.claude-code
+github.copilot
 github.copilot-chat
 
 # Git


### PR DESCRIPTION
- Add homebrew/cask-fonts tap and font-jetbrains-mono cask to match the font referenced in vscode/settings.json terminal config
- Add github.copilot base extension (required by github.copilot-chat)

https://claude.ai/code/session_01SgvazZnaPEhRRHSQ14YvPB