### PR TITLE
Fix VS Code Python interpreter path

### DIFF
--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -101,7 +101,7 @@
   },
 
   // Extensions: Python (via mise)
-  "python.defaultInterpreterPath": "~/.local/share/mise/shims/python",
+  "python.defaultInterpreterPath": "/Users/andrej/.local/share/mise/shims/python",
   "[python]": {
     "editor.defaultFormatter": "charliermarsh.ruff",
     "editor.codeActionsOnSave": {

--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -100,8 +100,8 @@
     "editor.defaultFormatter": "redhat.vscode-yaml"
   },
 
-  // Extensions: Python (via mise)
-  "python.defaultInterpreterPath": "/Users/andrej/.local/share/mise/shims/python",
+  // Extensions: Python
+  "python.defaultInterpreterPath": "python3",
   "[python]": {
     "editor.defaultFormatter": "charliermarsh.ruff",
     "editor.codeActionsOnSave": {


### PR DESCRIPTION
## Summary
- Revert `python.defaultInterpreterPath` from the mise shim path back to `python3`
- VS Code does not expand `~` or `${env:HOME}` in this setting, so the absolute shim path produced an "interpreter path could not be resolved" warning
- `python3` resolves via PATH (mise shims are on PATH via `mise activate` in `.zshrc`), avoiding a hardcoded username

## Why
An earlier refresh set the interpreter to `~/.local/share/mise/shims/python`, which VS Code surfaced as an unresolved-path error popup.

## Test plan
- [ ] Reload VS Code window; confirm no "interpreter path could not be resolved" warning
- [ ] Confirm Python extension picks up the mise-managed Python 3.14