### PR TITLE
June 2026 toolchain bump

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,4 +1,4 @@
 [tools]
 python = "3.14"
-node = "24"
+node = "26"
 go = "1.26"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/koalaman/shellcheck-precommit
-    rev: v0.10.0
+    rev: v0.11.0
     hooks:
       - id: shellcheck
         args: ["-s", "bash", "-e", "SC1090,SC1091"]


### PR DESCRIPTION
## Summary
- Bump node from 24 to 26 in `.mise.toml` (node 26.3.0 installed and verified locally)
- Bump shellcheck pre-commit hook from v0.10.0 to v0.11.0

## Notes
- Node 26 is the current release line but not yet LTS — node 24 remains the LTS pin if you prefer to wait
- Verified locally: `mise install` succeeds, `mise exec -- node -v` → v26.3.0, `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)